### PR TITLE
use consistent function names in taskmodule and pipeline

### DIFF
--- a/pytorch_ie/pipeline.py
+++ b/pytorch_ie/pipeline.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader
 
 from pytorch_ie.core.pytorch_ie import PyTorchIEModel
 from pytorch_ie.data.document import Document
-from pytorch_ie.taskmodules.taskmodule import TaskModule, TaskEncoding
+from pytorch_ie.taskmodules.taskmodule import TaskModule, TaskEncoding, DecodedModelOutput
 
 logger = logging.getLogger(__name__)
 
@@ -195,13 +195,15 @@ class Pipeline:
         """
         return self.model(input_tensors[0])
 
-    def postprocess(self, model_outputs: Dict, **postprocess_parameters: Dict) -> Any:
+    def postprocess(self, model_inputs: List[TaskEncoding], model_outputs: List[DecodedModelOutput],
+                    **postprocess_parameters: Dict) -> List[Document]:
         """
-        Postprocess will receive the raw outputs of the `_forward` method, generally tensors, and reformat them into
-        something more friendly. Generally it will output a list or a dict or results (containing just strings and
-        numbers).
+        Postprocess will receive the model inputs and (unbatched) model outputs and reformat them into
+        something more friendly. Generally it will output a list of documents.
         """
-        return self.taskmodule.decode_output(model_outputs)
+        # This creates annotations from the model outputs and attaches them to the correct documents.
+        # IMPORTANT: This might not return the documents in the same order as the input documents!
+        return self.taskmodule.decode(encodings=model_inputs, decoded_outputs=model_outputs)
 
     def get_inference_context(self):
         inference_context = (
@@ -269,19 +271,12 @@ class Pipeline:
         with torch.no_grad():
             for batch in dataloader:
                 output = self.forward(batch, **forward_params)
-                # converts: dict of lists -> list of dicts. This ensures that model_outputs will have the same length
-                # as model_inputs.
-                # (calls: self.taskmodule.decode_output(model_outputs))
-                # TODO: Should directly call self.taskmodule.decode_output(model_outputs).
-                processed_output = self.postprocess(output, **postprocess_params)
+                processed_output = self.taskmodule.unbatch_output(output)
                 model_outputs.extend(processed_output)
         assert len(model_inputs) == len(model_outputs), \
             f'length mismatch: len(model_inputs) [{len(model_inputs)}] != len(model_outputs) [{len(model_outputs)}]'
 
-        # This creates annotations from the model outputs and attaches them to the correct documents.
-        # IMPORTANT: This does not return the documents in the same order as the input documents!
-        # TODO: Should be named to postprocess and internally call taskmodule.decode (has to be implemented/adapted)
-        documents = self.taskmodule.combine(encodings=model_inputs, decoded_outputs=model_outputs, inplace=inplace)
+        documents = self.postprocess(model_inputs=model_inputs, model_outputs=model_outputs, **postprocess_params)
         if single_document:
             return documents[0]
         else:

--- a/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -369,7 +369,7 @@ class TransformerRETextClassificationTaskModule(TaskModule):
 
         return target
 
-    def decode_output(self, output: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def unbatch_output(self, output: Dict[str, Any]) -> List[Dict[str, Any]]:
         logits = output["logits"]
 
         output_label_probs = logits.sigmoid() if self.multi_label else logits.softmax(dim=-1)
@@ -388,7 +388,7 @@ class TransformerRETextClassificationTaskModule(TaskModule):
 
         return decoded_output
 
-    def decoded_output_to_annotations(
+    def create_annotations_from_output(
         self,
         output: Dict[str, Any],
         encoding: TaskEncoding,

--- a/pytorch_ie/taskmodules/transformer_span_classification.py
+++ b/pytorch_ie/taskmodules/transformer_span_classification.py
@@ -166,7 +166,7 @@ class TransformerSpanClassificationTaskModule(TaskModule):
 
         return target
 
-    def decode_output(self, output: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def unbatch_output(self, output: Dict[str, Any]) -> List[Dict[str, Any]]:
         logits = output["logits"]
         probs = F.softmax(logits, dim=-1).detach().cpu().numpy()
         label_ids = torch.argmax(logits, dim=-1).detach().cpu().numpy()
@@ -188,7 +188,7 @@ class TransformerSpanClassificationTaskModule(TaskModule):
         # labels = [[self.id_to_label[e] for e in b] for b in label_ids]
         return [{"tags": t, "probabilities": p} for t, p in zip(tags, probabilities)]
 
-    def decoded_output_to_annotations(
+    def create_annotations_from_output(
         self,
         output: Dict[str, Any],
         encoding: TaskEncoding,

--- a/pytorch_ie/taskmodules/transformer_text_classification.py
+++ b/pytorch_ie/taskmodules/transformer_text_classification.py
@@ -128,7 +128,7 @@ class TransformerTextClassificationTaskModule(TaskModule):
 
         return target
 
-    def decode_output(self, output: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def unbatch_output(self, output: Dict[str, Any]) -> List[Dict[str, Any]]:
         logits = output["logits"]
 
         output_label_probs = logits.sigmoid() if self.multi_label else logits.softmax(dim=-1)
@@ -164,7 +164,7 @@ class TransformerTextClassificationTaskModule(TaskModule):
 
         return decoded_output
 
-    def decoded_output_to_annotations(
+    def create_annotations_from_output(
         self,
         output: Dict[str, Any],
         encoding: TaskEncoding,

--- a/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -181,14 +181,14 @@ class TransformerTokenClassificationTaskModule(TaskModule):
 
         return target
 
-    def decode_output(self, output: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def unbatch_output(self, output: Dict[str, Any]) -> List[Dict[str, Any]]:
         logits = output["logits"]
         probabilities = F.softmax(logits, dim=-1).detach().cpu().numpy()
         indices = torch.argmax(logits, dim=-1).detach().cpu().numpy()
         tags = [[self.id_to_label[e] for e in b] for b in indices]
         return [{"tags": t, "probabilities": p} for t, p in zip(tags, probabilities)]
 
-    def decoded_output_to_annotations(
+    def create_annotations_from_output(
         self,
         output: Dict[str, Any],
         encoding: TaskEncoding,


### PR DESCRIPTION
renaming in taskmodule:
* decode_output -> unbatch_output
* combine -> decode
* decoded_output_to_annotations -> create_annotations_from_output
 
and in pipeline:
* unbatch_output is called directly in dataloader loop
* postprocess is called in the end with model_inputs (encodings) and model_outputs and calls decode

Some documentation added to (abstract) functions.
