### PR TITLE
implement windowing for text classification based rel

### DIFF
--- a/pytorch_ie/data/document.py
+++ b/pytorch_ie/data/document.py
@@ -182,24 +182,20 @@ class Document:
         self._predictions[name].append(prediction)
 
     # TODO: rework all getters for annotations (e.g. remove type: ignore)
-    def annotations(self, name: str, default: AnnotationLayer = []) -> AnnotationLayer:
-        return self._annotations.get(name, default)
+    def annotations(self, name: str) -> AnnotationLayer:
+        return self._annotations.get(name, [])
 
-    def span_annotations(
-        self, name: str, default: Optional[AnnotationLayer] = []
-    ) -> List[LabeledSpan]:
-        return self.annotations(name=name, default=default)  # type: ignore
+    def span_annotations(self, name: str) -> List[LabeledSpan]:
+        return self.annotations(name=name)  # type: ignore
 
-    def relation_annotations(
-        self, name: str, default: Optional[AnnotationLayer] = []
-    ) -> List[BinaryRelation]:
-        return self.annotations(name=name, default=default)  # type: ignore
+    def relation_annotations(self, name: str) -> List[BinaryRelation]:
+        return self.annotations(name=name)  # type: ignore
 
-    def label_annotations(self, name: str, default: Optional[AnnotationLayer] = []) -> List[Label]:
-        return self.annotations(name=name, default=default)  # type: ignore
+    def label_annotations(self, name: str) -> List[Label]:
+        return self.annotations(name=name)  # type: ignore
 
-    def predictions(self, name: str, default: AnnotationLayer = []) -> AnnotationLayer:
-        return self._predictions.get(name, default)
+    def predictions(self, name: str) -> AnnotationLayer:
+        return self._predictions.get(name, [])
 
     def clear_predictions(self, name: str) -> None:
         if name in self._predictions:

--- a/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -350,7 +350,7 @@ class TransformerRETextClassificationTaskModule(_TransformerReTextClassification
 
         for document in documents:
             entities = document.span_annotations(self.entity_annotation)
-            relations = document.relation_annotations(self.relation_annotation, default=None)
+            relations = document.relation_annotations(self.relation_annotation)
             relation_mapping = {(rel.head, rel.tail): rel.label for rel in relations or []}
 
             partitions: Sequence[Optional[LabeledSpan]]


### PR DESCRIPTION
As discussed. Tested on example prediction pipeline, train run ~~is still running, but looks good.~~ EDIT: finished successful.

~~This also adds a parameter `add_negative_examples` that allows to add all relation candidates that are not in the existing relations as relations with non_label, i.e. `no_relation`.~~ EDIT: This was removed again as it does not proved as useful as expected.

This outsources several parts of the `encode_inputs` method to test them separately.

relevant changes:
- implement token based windowing. This is activated if `max_window` is provided. The `max_window` defines the maximum number of token ids in the encoded input (takes added marker and special tokens into account), i.e. it is ready to be set to the max input size of the respective transformer. 
- annotation getters for `Document` take a default argument. By calling them with `default=None` it is possible to know if relations are available and should be taken into account to filter entity pair candidates or not (like for inference). This is relevant when not all documents in the training set have relations. This was previously causing to add all possible entity pair combinations for such documents as training instances.
- outsource `_get_window_around_slice` and add tests
- outsource `_encode_text` to easy testing
- outsource `_enumerate_entity_pairs` and add tests
- add tests for partitioning (since we are already on it)
- add tests for windowing

NOTE: This revealed a bug in `decode()`, see #62. The tests for `decode()` are not complete (but pipeline tests run as expected) and should be fixed in the respective PR.