### PR TITLE
Fix brat serialization with newlines

### DIFF
--- a/pytorch_ie/data/datasets/brat.py
+++ b/pytorch_ie/data/datasets/brat.py
@@ -143,16 +143,19 @@ def load_brat(
     }
 
 
-def split_span_annotation(text: str, start: int, end: int, glue: str) -> List[Tuple[int, int]]:
-    pos = text.find(glue, start)
-    starts = [start]
+def split_span_annotation(text: str, slice: Tuple[int, int], glue: str) -> List[Tuple[int, int]]:
+    """
+    Split the text contained in the slice by `glue` and return the respective new slices.
+    """
+    pos = text.find(glue, slice[0])
+    starts = [slice[0]]
     ends = []
-    while pos >= 0 and pos + len(glue) <= end:
+    while pos >= 0 and pos + len(glue) <= slice[1]:
         ends.append(pos)
         starts.append(pos + len(glue))
         pos = text.find(glue, pos + 1)
 
-    ends.append(end)
+    ends.append(slice[1])
     return list(zip(starts, ends))
 
 
@@ -162,7 +165,7 @@ def serialize_labeled_span(
     # We have to remove newline characters from the annotations because this will cause
     # problems for the brat annotation file. So, we create fragments around newlines.
     slices = split_span_annotation(
-        text=doc.text, start=annotation.start, end=annotation.end, glue=GLUE_TEXT
+        text=doc.text, slice=(annotation.start, annotation.end), glue=GLUE_TEXT
     )
     slices_serialized = ";".join([f"{start} {end}" for start, end in slices])
     _text = GLUE_BRAT.join([doc.text[start:end] for start, end in slices])

--- a/tests/data/datasets/test_brat.py
+++ b/tests/data/datasets/test_brat.py
@@ -223,26 +223,18 @@ def test_split_span_annotation():
 
     text_wo_nl = "This is a text without newlines."
     span_slice = (0, len(text_wo_nl))
-    slices = split_span_annotation(
-        text=text_wo_nl, start=span_slice[0], end=span_slice[1], glue="\n"
-    )
+    slices = split_span_annotation(text=text_wo_nl, slice=span_slice, glue="\n")
     assert slices == [span_slice]
 
     span_slice = (3, 15)
-    slices = split_span_annotation(
-        text=text_wo_nl, start=span_slice[0], end=span_slice[1], glue="\n"
-    )
+    slices = split_span_annotation(text=text_wo_nl, slice=span_slice, glue="\n")
     assert slices == [span_slice]
 
     text_with_nl = "This is a text\nwith\nnewlines."
     span_slice = (0, len(text_with_nl))
-    slices = split_span_annotation(
-        text=text_with_nl, start=span_slice[0], end=span_slice[1], glue="\n"
-    )
+    slices = split_span_annotation(text=text_with_nl, slice=span_slice, glue="\n")
     assert slices == [(0, 14), (15, 19), (20, 29)]
 
     span_slice = (3, 18)
-    slices = split_span_annotation(
-        text=text_with_nl, start=span_slice[0], end=span_slice[1], glue="\n"
-    )
+    slices = split_span_annotation(text=text_with_nl, slice=span_slice, glue="\n")
     assert slices == [(3, 14), (15, 18)]


### PR DESCRIPTION
When spans contain newlines, the serialization to BRAT was not correctly implemented and newlines occurred in the text extracts in the .ann files resulting in truncated lines. This PR handles newlines in span annotations by creating fragmented spans around the newline character.