### PR TITLE
make it optional to include ill formed spans when predicting

### DIFF
--- a/pytorch_ie/data/span_utils.py
+++ b/pytorch_ie/data/span_utils.py
@@ -14,7 +14,7 @@ class InvalidTagSequence(Exception):
 
 
 def bio_tags_to_spans(
-    tag_sequence: List[str], classes_to_ignore: List[str] = None
+    tag_sequence: List[str], classes_to_ignore: List[str] = None, include_ill_formed: bool = True
 ) -> List[TypedStringSpan]:
     """
     Given a sequence corresponding to BIO tags, extracts spans.
@@ -29,6 +29,8 @@ def bio_tags_to_spans(
     classes_to_ignore : `List[str]`, optional (default = `None`).
         A list of string class labels `excluding` the bio tag
         which should be ignored when extracting spans.
+    include_ill_formed: `bool`, optional (default = `True`).
+        If this flag is enabled, include spans that do not start with "B". Otherwise, these are ignored.
     # Returns
     spans : `List[TypedStringSpan]`
         The typed, extracted spans from the sequence, in the format (label, (span_start, span_end)).
@@ -74,9 +76,15 @@ def bio_tags_to_spans(
             # false positive ill-formed spans.
             if active_conll_tag is not None:
                 spans.add((active_conll_tag, (span_start, span_end)))
-            active_conll_tag = conll_tag
-            span_start = index
-            span_end = index
+            if include_ill_formed:
+                active_conll_tag = conll_tag
+                span_start = index
+                span_end = index
+            else:
+                active_conll_tag = None
+                # We don't care about tags we are
+                # told to ignore, so we do nothing.
+                continue
     # Last token might have been a part of a valid span.
     if active_conll_tag is not None:
         spans.add((active_conll_tag, (span_start, span_end)))

--- a/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -160,6 +160,7 @@ class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTa
         max_window: Optional[int] = None,
         window_overlap: int = 0,
         show_statistics: bool = False,
+        include_ill_formed_predictions: bool = True,
     ) -> None:
         super().__init__()
         self.save_hyperparameters()
@@ -177,6 +178,7 @@ class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTa
         self.max_window = max_window
         self.window_overlap = window_overlap
         self.show_statistics = show_statistics
+        self.include_ill_formed_predictions = include_ill_formed_predictions
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config()
@@ -389,7 +391,9 @@ class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTa
             )
         ]
 
-        spans = bio_tags_to_spans(tag_sequence)
+        spans = bio_tags_to_spans(
+            tag_sequence, include_ill_formed=self.include_ill_formed_predictions
+        )
         for label, (start, end) in spans:
             yield (
                 self.entity_annotation,


### PR DESCRIPTION
When the BIO-labeled predictions contains spans that start with an "I", these may be excluded by setting `include_ill_formed_predictions=False`. The previous behavior is achieved with `include_ill_formed_predictions=True` which is the default.