### PR TITLE
use commit hash instead of date for pre-release identifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
               run: |
                   poetry version patch &&
                   version=$(poetry version | awk '{ print $2 }') &&
-                  poetry version $version.dev.$(date +%s)
+                  poetry version $version.dev.$(git rev-parse --short "$GITHUB_SHA")
             - name: Build package
               run: |
                   poetry build --ansi


### PR DESCRIPTION
Implements #103.