### PR TITLE
Make readme examples work in interactive interpreter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ PyTorch-IE: State-of-the-art Information Extraction in PyTorch
 
 ⚡️ Examples
 ------------
-**Note:** Setting ``num_workers=0`` in the pipeline is only necessary when running an example in an 
+**Note:** Setting ``num_workers=0`` in the pipeline is only necessary when running an example in an
 interactive python session. The reason is that multiprocessing doesn't play well with the interactive python
 interpreter, see `here <https://docs.python.org/3/library/multiprocessing.html#using-a-pool-of-workers>`_
 for details.


### PR DESCRIPTION
The issue was that multiprocessing requires `__main__` to be importable (see https://docs.python.org/3/library/multiprocessing.html#using-a-pool-of-workers), which makes the example fail when run in an interactive interpreter session. The fix is to disable multiprocessing by setting `num_workers=0` in the examples.