### PR TITLE
[WIP] Integrate predictions

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -1,7 +1,7 @@
 import dataclasses
 import typing
 from collections.abc import Mapping, Sequence
-from typing import Any, Dict, List, Optional, Set, Tuple, TypeVar, Union, overload
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union, overload
 
 
 def _depth_first_search(lst: List[str], visited: Set[str], graph: Dict[str, List[str]], node: str):
@@ -105,6 +105,12 @@ class AnnotationList(BaseAnnotationList[T]):
     @property
     def predictions(self) -> BaseAnnotationList[T]:
         return self._predictions
+
+    def integrate_predictions(self, overwrite: bool = False):
+        if overwrite:
+            self.clear()
+        self.extend(self.predictions)
+        self._predictions._annotations = []
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, AnnotationList):


### PR DESCRIPTION
This implements `AnnotationList.integrate_predictions(overwrite: bool = False)` which allows to move predictions to the main annotations.