### PR TITLE
Fix create annotations from output for seq2seq

### DIFF
--- a/src/pytorch_ie/taskmodules/transformer_seq2seq.py
+++ b/src/pytorch_ie/taskmodules/transformer_seq2seq.py
@@ -167,6 +167,7 @@ class TransformerSeq2SeqTaskModule(_TransformerSeq2SeqTaskModule):
             # for now, just use the first head and tail match in the document
             text = task_encoding.document.text.lower()
             try:
+                # this may fail if head_entity or tail_entity contains any special regex character (e.g. brackets)
                 head_match = re.search(head_entity.lower(), text)
                 tail_match = re.search(tail_entity.lower(), text)
             except Exception:


### PR DESCRIPTION
Before this PR, the `TransformerSeq2SeqTaskModule.create_annotations_from_output` crashed when the generated head or tail contains special regex characters (e.g. brackets). Now, we catch any exception, skip the triplet and just log a warning. This may not be perfectly in favor of the prediction quality (we may skip correct relation predictions), but is a pragmatic fix for now.   