### PR TITLE
add `TaskModule.configure_model_metric(stage)`

### DIFF
--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union, ov
 
 import torch.utils.data.dataset as torch_dataset
 from pytorch_lightning.core.mixins import HyperparametersMixin
+from torchmetrics import Metric
 from tqdm import tqdm
 
 from pytorch_ie.core.document import Annotation, Document
@@ -447,3 +448,10 @@ class TaskModule(
         self, task_encodings: Sequence[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]]
     ) -> TaskBatchEncoding:
         pass
+
+    def configure_model_metric(self, stage: str) -> Optional[Metric]:
+        logger.warning(
+            f"TaskModule {self.__class__.__name__} does not implement a model metric. "
+            f"Override configure_model_metric(stage) to configure a metric for stage '{stage}'."
+        )
+        return None


### PR DESCRIPTION
This adds the interface method `configure_model_metric(stage: str) -> Optional[Metric]` to the `TaskModule` class. Per default, it returns just `None`. Taskmodule implementations can override this to return a `torchmetrics.Metric` which should accept a batch of model outputs and targets. By having this method defined in the taskmodule, it is possible to use its `unbatch_output` and any available annotation decoding logic. Then, a `PyTorchIEModel` implementation can use this to easily create metrics that match the data without re-implementing any specific decoding logic.