### PR TITLE
call `post_prepare()` in `TaskModuel._from_config()`

### DIFF
--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -390,7 +390,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
 
     @classmethod
     def _from_pretrained(
-        cls,
+        cls: Type[T],
         *,
         model_id: str,
         revision: Optional[str],
@@ -404,7 +404,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         strict: bool = False,
         config: Optional[dict] = None,
         **model_kwargs,
-    ) -> "PieModelHFHubMixin":
+    ) -> T:
         """Load Pytorch pretrained weights and return the loaded model."""
         if os.path.isdir(model_id):
             logger.info("Loading weights from local directory")
@@ -447,7 +447,7 @@ class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
 
     @classmethod
     def _from_pretrained(
-        cls,
+        cls: Type[T],
         *,
         model_id: str,
         revision: Optional[str],
@@ -461,7 +461,7 @@ class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
         strict: bool = False,
         config: Optional[dict] = None,
         **taskmodule_kwargs,
-    ) -> "PieTaskModuleHFHubMixin":
+    ) -> T:
         config = (config or {}).copy()
         config.update(taskmodule_kwargs)
         if cls.config_type_key is not None:

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -168,6 +168,12 @@ class TaskModule(
         taskmodule.post_prepare()
         return taskmodule
 
+    @classmethod
+    def _from_config(cls: Type["TaskModule"], config: Dict[str, Any], **kwargs) -> "TaskModule":
+        taskmodule: TaskModule = super()._from_config(config, **kwargs)
+        taskmodule.post_prepare()
+        return taskmodule
+
     def batch_encode(
         self,
         documents: Sequence[DocumentType],

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -2,7 +2,7 @@ import copy
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Sequence
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union, overload
+from typing import Any, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union, overload
 
 import torch.utils.data.dataset as torch_dataset
 from pytorch_lightning.core.mixins import HyperparametersMixin
@@ -160,10 +160,10 @@ class TaskModule(
 
     @classmethod
     def _from_pretrained(
-        cls,
+        cls: Type["TaskModule"],
         *args,
         **kwargs,
-    ):
+    ) -> "TaskModule":
         taskmodule: TaskModule = super()._from_pretrained(*args, **kwargs)
         taskmodule.post_prepare()
         return taskmodule

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -26,6 +26,7 @@ def test_auto_taskmodule():
     taskmodule = AutoTaskModule.from_pretrained("pie/example-ner-spanclf-conll03")
     assert isinstance(taskmodule, TransformerSpanClassificationTaskModule)
     assert taskmodule.label_to_id == {"O": 0, "MISC": 1, "ORG": 2, "PER": 3, "LOC": 4}
+    assert taskmodule.is_prepared
 
 
 @pytest.mark.slow
@@ -67,6 +68,7 @@ def test_auto_taskmodule_from_config():
     }
     taskmodule = AutoTaskModule.from_config(config)
     assert isinstance(taskmodule, MyTransformerSpanClassificationTaskModule)
+    assert taskmodule.is_prepared
 
 
 @pytest.mark.slow


### PR DESCRIPTION
The loaded task module should be ready to use when loading from config, in the same way as when loading from pretrained. This was missed in #395.