### PR TITLE
`Annotation.(target|targets|named_targets)` return never `None`

### DIFF
--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -70,7 +70,7 @@ class Span(Annotation):
 
     def __str__(self) -> str:
         if not self.is_attached:
-            return ""
+            return super().__str__()
         return str(self.target[self.start : self.end])
 
 

--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -69,7 +69,7 @@ class Span(Annotation):
     end: int
 
     def __str__(self) -> str:
-        if self.target is None:
+        if not self.is_attached:
             return ""
         return str(self.target[self.start : self.end])
 

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -13,6 +13,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
     overload,
@@ -47,13 +48,13 @@ def _enumerate_dependencies(
                 resolved.append(node)
 
 
-def _is_optional_type(t: typing.Type) -> bool:
+def _is_optional_type(t: Type) -> bool:
     type_origin = typing.get_origin(t)
     type_args = typing.get_args(t)
     return type_origin is typing.Union and len(type_args) == 2 and type(None) in type_args
 
 
-def _is_optional_annotation_type(t: typing.Type) -> bool:
+def _is_optional_annotation_type(t: Type) -> bool:
     is_optional = _is_optional_type(t)
     if not is_optional:
         return False
@@ -87,7 +88,7 @@ def _is_tuple_of_annotation_types(t: Any) -> bool:
 
 
 def _get_reference_fields_and_container_types(
-    annotation_class: typing.Type["Annotation"],
+    annotation_class: Type["Annotation"],
 ) -> Dict[str, Any]:
     containers: Dict[str, Any] = {}
     for field in dataclasses.fields(annotation_class):
@@ -498,7 +499,7 @@ class Document(Mapping[str, Any]):
         ]
 
     @classmethod
-    def field_types(cls) -> Dict[str, typing.Type]:
+    def field_types(cls) -> Dict[str, Type]:
         result = {}
         for f in cls.fields():
             # If we got just the string representation of the type, we resolve the whole class.
@@ -610,7 +611,7 @@ class Document(Mapping[str, Any]):
         return dct
 
     @classmethod
-    def fromdict(cls: typing.Type[D], dct) -> D:
+    def fromdict(cls: Type[D], dct: Dict) -> D:
         fields = dataclasses.fields(cls)
         annotation_fields = cls.annotation_fields()
         field_types = cls.field_types()
@@ -685,7 +686,7 @@ class Document(Mapping[str, Any]):
 
     def as_type(
         self,
-        new_type: typing.Type[D],
+        new_type: Type[D],
         field_mapping: Optional[Dict[str, str]] = None,
         keep_remaining: bool = True,
     ) -> D:

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -198,30 +198,30 @@ class Annotation:
         return hash((self, self.non_comparison_fields_and_values))
 
     @property
-    def target(self) -> Optional[TARGET_TYPE]:
-        if self._targets is None:
-            return None
-        if len(self._targets) == 0:
+    def target(self) -> TARGET_TYPE:
+        targets = self.targets
+        if len(targets) == 0:
             raise ValueError(f"annotation has no target")
-        if len(self._targets) > 1:
+        if len(targets) > 1:
             raise ValueError(
                 f"annotation has multiple targets, target is not defined in this case"
             )
-        return self._targets[0]
+        return targets[0]
 
     @property
-    def targets(self) -> Optional[Tuple[TARGET_TYPE, ...]]:
-        return self._targets
-
-    @property
-    def named_targets(self) -> Dict[str, TARGET_TYPE]:
+    def targets(self) -> Tuple[TARGET_TYPE, ...]:
         if self._targets is None:
             raise ValueError(
                 f"targets is not set (this annotation may be not yet attached to a document)"
             )
+        return self._targets
+
+    @property
+    def named_targets(self) -> Dict[str, TARGET_TYPE]:
+        targets = self.targets
         if self.TARGET_NAMES is None:
             raise TypeError(f"no TARGET_NAMES defined")
-        return {name: self._targets[i] for i, name in enumerate(self.TARGET_NAMES)}
+        return {name: targets[i] for i, name in enumerate(self.TARGET_NAMES)}
 
     def _asdict(
         self,
@@ -610,7 +610,7 @@ class Document(Mapping[str, Any]):
         return dct
 
     @classmethod
-    def fromdict(cls, dct):
+    def fromdict(cls: typing.Type[D], dct) -> D:
         fields = dataclasses.fields(cls)
         annotation_fields = cls.annotation_fields()
         field_types = cls.field_types()
@@ -634,8 +634,8 @@ class Document(Mapping[str, Any]):
             nodes=doc._annotation_graph["_artificial_root"],
         )
 
-        annotations = {}
-        predictions = {}
+        annotations: Dict[int, Annotation] = {}
+        predictions: Dict[int, Annotation] = {}
         annotations_per_field = defaultdict(list)
         predictions_per_field = defaultdict(list)
         for field_name in dependency_ordered_fields:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -262,16 +262,16 @@ def test_annotation_list():
 
     entity1 = LabeledSpan(start=0, end=8, label="PER")
     entity2 = LabeledSpan(start=18, end=19, label="ORG")
-    assert entity1.target is None
-    assert entity2.target is None
+    assert not entity1.is_attached
+    assert not entity2.is_attached
 
     document.entities.append(entity1)
     document.entities.append(entity2)
 
     entity3 = LabeledSpan(start=18, end=19, label="PRED-ORG")
     entity4 = LabeledSpan(start=0, end=8, label="PRED-PER")
-    assert entity3.target is None
-    assert entity4.target is None
+    assert not entity3.is_attached
+    assert not entity4.is_attached
 
     document.entities.predictions.append(entity3)
     document.entities.predictions.append(entity4)
@@ -299,13 +299,13 @@ def test_annotation_list():
 
     document.entities.clear()
     assert len(document.entities) == 0
-    assert entity1.target is None
-    assert entity2.target is None
+    assert not entity1.is_attached
+    assert not entity2.is_attached
 
     document.entities.predictions.clear()
     assert len(document.entities.predictions) == 0
-    assert entity3.target is None
-    assert entity4.target is None
+    assert not entity3.is_attached
+    assert not entity4.is_attached
 
 
 def test_annotation_list_with_multiple_targets():
@@ -335,19 +335,19 @@ def test_annotation_list_with_multiple_targets():
     }
 
     span1 = LabeledSpan(0, 2, label="a")
-    assert span1.targets is None
+    assert not span1.is_attached
     doc.entities1.append(span1)
     assert doc.entities1[0] == span1
     assert span1.target == doc.text
 
     span2 = LabeledSpan(2, 4, label="b")
-    assert span2.targets is None
+    assert not span2.is_attached
     doc.entities2.append(span2)
     assert doc.entities2[0] == span2
     assert span2.target == doc.text
 
     relation = BinaryRelation(head=span1, tail=span2, label="relation")
-    assert relation.targets is None
+    assert not relation.is_attached
     doc.relations.append(relation)
     assert doc.relations[0] == relation
     with pytest.raises(
@@ -358,7 +358,7 @@ def test_annotation_list_with_multiple_targets():
     assert relation.targets == (doc.entities1, doc.entities2)
 
     label = Label("label")
-    assert label.target is None
+    assert not label.is_attached
     doc.label.append(label)
     assert doc.label[0] == label
     with pytest.raises(ValueError, match=re.escape("annotation has no target")):
@@ -378,7 +378,7 @@ class DoubleTextSpan(Annotation):
     end2: int
 
     def __str__(self) -> str:
-        if self.targets is None:
+        if not self.is_attached:
             return ""
         text1: str = self.named_targets["text1"]  # type: ignore
         text2: str = self.named_targets["text2"]  # type: ignore
@@ -415,19 +415,19 @@ def test_annotation_list_with_named_targets():
     }
 
     span1 = LabeledSpan(0, 2, label="a")
-    assert span1.targets is None
+    assert not span1.is_attached
     doc.entities1.append(span1)
     assert doc.entities1[0] == span1
     assert span1.target == doc.texta
 
     span2 = LabeledSpan(2, 4, label="b")
-    assert span2.targets is None
+    assert not span2.is_attached
     doc.entities2.append(span2)
     assert doc.entities2[0] == span2
     assert span2.target == doc.textb
 
     doublespan = DoubleTextSpan(0, 2, 1, 5)
-    assert doublespan.targets is None
+    assert not doublespan.is_attached
     doc.crossrefs.append(doublespan)
     assert doc.crossrefs[0] == doublespan
     assert doublespan.named_targets == {"text1": doc.texta, "text2": doc.textb}
@@ -442,7 +442,7 @@ def test_annotation_list_with_named_targets_mismatch_error():
         end: int
 
         def __str__(self) -> str:
-            if self.targets is None:
+            if not self.is_attached:
                 return ""
             text: str = self.named_targets["text"]  # type: ignore
             return str(text[self.start : self.end])


### PR DESCRIPTION
With this PR, the properties `Annotation.(target|targets|named_targets)` return never None, **but raise a `ValueError` if the annotation is not attached** to a document. This clarifies the semantics and mitigates typing issues. It is recommended to first check with `Annotation.is_attached` before using one of the above properties.

Note: This also changes the string representation of the `Span` annotation if it is not attached to just returning `super().__str__()` (instead of the empty string as it was before).