### PR TITLE
Add multi span annotation types and documents

### DIFF
--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -3,7 +3,14 @@ from typing import Any, Dict, Optional, Tuple
 
 from typing_extensions import TypeAlias
 
-from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, MultiLabel, Span
+from pytorch_ie.annotations import (
+    BinaryRelation,
+    Label,
+    LabeledMultiSpan,
+    LabeledSpan,
+    MultiLabel,
+    Span,
+)
 from pytorch_ie.core import AnnotationLayer, Document, annotation_field
 
 
@@ -133,5 +140,32 @@ class TextDocumentWithSpansBinaryRelationsAndLabeledPartitions(
     TextDocumentWithSpansAndLabeledPartitions,
     TextDocumentWithSpansAndBinaryRelations,
     TextDocumentWithLabeledPartitions,
+):
+    pass
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledMultiSpans(TextBasedDocument):
+    labeled_multi_spans: AnnotationLayer[LabeledMultiSpan] = annotation_field(target="text")
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledMultiSpansAndLabeledPartitions(
+    TextDocumentWithLabeledMultiSpans, TextDocumentWithLabeledPartitions
+):
+    pass
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledMultiSpansAndBinaryRelations(TextDocumentWithLabeledMultiSpans):
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(
+        target="labeled_multi_spans"
+    )
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions(
+    TextDocumentWithLabeledMultiSpansAndLabeledPartitions,
+    TextDocumentWithLabeledMultiSpansAndBinaryRelations,
 ):
     pass

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -7,6 +7,7 @@ from pytorch_ie import AnnotationLayer, annotation_field
 from pytorch_ie.annotations import (
     BinaryRelation,
     Label,
+    LabeledMultiSpan,
     LabeledSpan,
     MultiLabel,
     MultiLabeledBinaryRelation,
@@ -173,6 +174,31 @@ def test_multilabeled_span():
     multilabeled_span = MultiLabeledSpan(start=7, end=12, label=("LOC", "ORG"))
     doc.spans.append(multilabeled_span)
     assert multilabeled_span.resolve() == (("LOC", "ORG"), "world")
+
+
+def test_labeled_multi_span():
+    labeled_multi_span1 = LabeledMultiSpan(slices=((1, 2), (3, 4)), label="label1")
+    assert labeled_multi_span1.slices == ((1, 2), (3, 4))
+    assert labeled_multi_span1.label == "label1"
+    assert labeled_multi_span1.score == pytest.approx(1.0)
+
+    labeled_multi_span2 = LabeledMultiSpan(
+        slices=((5, 6), (7, 8)),
+        label="label2",
+        score=0.5,
+    )
+    assert labeled_multi_span2.slices == ((5, 6), (7, 8))
+    assert labeled_multi_span2.label == "label2"
+    assert labeled_multi_span2.score == pytest.approx(0.5)
+
+    assert labeled_multi_span2.asdict() == {
+        "_id": labeled_multi_span2._id,
+        "slices": ((5, 6), (7, 8)),
+        "label": "label2",
+        "score": 0.5,
+    }
+
+    _test_annotation_reconstruction(labeled_multi_span2)
 
 
 def test_binary_relation():


### PR DESCRIPTION
This PR adds the annotation types: 
 - `MultiSpan` and 
 - `LabeledMultiSpan`.
  
 It also adds the following document types:
- `TextDocumentWithLabeledMultiSpans`, 
- `TextDocumentWithLabeledMultiSpansAndLabeledPartitions`,
- `TextDocumentWithLabeledMultiSpansAndBinaryRelations`, and
- `TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions`.
