### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
-pip==23.2.1
-nox==2023.4.22
+pip==24.0
+nox==2024.4.15
 nox-poetry==1.0.3
-poetry==1.6.1
-virtualenv==20.24.4
+poetry==1.8.2
+virtualenv==20.25.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,8 @@ jobs:
                       print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
             - name: Install Poetry
               run: |
-                  pipx install --verbose --pip-args=--constraint=.github/workflows/constraints.txt poetry
+                  # pipx install --verbose --pip-args=--constraint=.github/workflows/constraints.txt poetry
+                  pipx install poetry
                   poetry --version
             - name: Install Nox
               run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,12 +116,12 @@ jobs:
                   pip --version
             - name: Install Poetry
               run: |
-                  pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+                  pipx install --pip-args=--constraint=$(pwd)/.github/workflows/constraints.txt poetry
                   poetry --version
             - name: Install Nox
               run: |
-                  pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-                  pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+                  pipx install --pip-args=--constraint=$(pwd)/.github/workflows/constraints.txt nox
+                  pipx inject --pip-args=--constraint=$(pwd)/.github/workflows/constraints.txt nox nox-poetry
                   nox --version
             - name: Download coverage data
               uses: actions/download-artifact@v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,8 @@ jobs:
                       print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
             - name: Install Poetry
               run: |
+                  pwd
+                  ls -la
                   # pipx install --verbose --pip-args=--constraint=.github/workflows/constraints.txt poetry
                   pipx install poetry
                   poetry --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,8 +60,8 @@ jobs:
                   poetry --version
             - name: Install Nox
               run: |
-                  pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-                  pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+                  pipx install --pip-args=--constraint=/home/runner/work/pytorch-ie/pytorch-ie/.github/workflows/constraints.txt nox
+                  pipx inject --pip-args=--constraint=/home/runner/work/pytorch-ie/pytorch-ie/.github/workflows/constraints.txt nox nox-poetry
                   nox --version
             - name: Compute pre-commit cache key
               if: matrix.session == 'pre-commit'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,15 +53,13 @@ jobs:
                       print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
             - name: Install Poetry
               run: |
-                  pwd
-                  ls -la
-                  # pipx install --verbose --pip-args=--constraint=.github/workflows/constraints.txt poetry
-                  pipx install poetry
+                  # pwd output: /home/runner/work/pytorch-ie/pytorch-ie
+                  pipx install --verbose --pip-args=--constraint=$(pwd)/.github/workflows/constraints.txt poetry
                   poetry --version
             - name: Install Nox
               run: |
-                  pipx install --pip-args=--constraint=/home/runner/work/pytorch-ie/pytorch-ie/.github/workflows/constraints.txt nox
-                  pipx inject --pip-args=--constraint=/home/runner/work/pytorch-ie/pytorch-ie/.github/workflows/constraints.txt nox nox-poetry
+                  pipx install --pip-args=--constraint=$(pwd)/.github/workflows/constraints.txt nox
+                  pipx inject --pip-args=--constraint=$(pwd)/.github/workflows/constraints.txt nox nox-poetry
                   nox --version
             - name: Compute pre-commit cache key
               if: matrix.session == 'pre-commit'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,10 +31,10 @@ jobs:
 
         steps:
             - name: Check out the repository
-              uses: actions/checkout@v2.4.0
+              uses: actions/checkout@v4
 
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v2.3.2
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python }}
                   #   cache: pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
                       print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
             - name: Install Poetry
               run: |
-                  pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+                  pipx install --verbose --pip-args=--constraint=.github/workflows/constraints.txt poetry
                   poetry --version
             - name: Install Nox
               run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -1397,6 +1397,51 @@ files = [
 ]
 
 [[package]]
+name = "numpy"
+version = "1.26.4"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
+    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
+    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
+    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
+    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
+    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
+    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
+    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
+    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
+    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
+]
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -1506,6 +1551,7 @@ files = [
 numpy = [
     {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -1832,6 +1878,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},


### PR DESCRIPTION
The CI workflows suddenly broke. This PR fixes it by switching to the absolute path for the `constraints.txt` file when used by `pipx`. In addition, this PR also updates the entries in the constraints file to the latest versions (same for some actions).