### PR TITLE
install `poetry-plugin-export` manually in tests workflow [WIP]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,7 @@ jobs:
               run: |
                   # pwd output: /home/runner/work/pytorch-ie/pytorch-ie
                   pipx install --verbose --pip-args=--constraint=$(pwd)/.github/workflows/constraints.txt poetry
+                  pipx inject --pip-args=--constraint=$(pwd)/.github/workflows/constraints.txt poetry poetry-plugin-export
                   poetry --version
             - name: Install Nox
               run: |


### PR DESCRIPTION
to resolve poetry deprecation warning from ci (during `Run Nox` step):
```
nox > poetry export --format=requirements.txt --with=dev --without-hashes
Warning: poetry-plugin-export will not be installed by default in a future version of Poetry.
In order to avoid a breaking change and make your automation forward-compatible, please install poetry-plugin-export explicitly. See https://python-poetry.org/docs/plugins/#using-plugins for details on how to install a plugin.
To disable this warning run 'poetry config warnings.export false'.
```

Warning: This does not seem to work as expected, the warning is still shown. Needs some further investigation. 

EDIT: This should use this instead when available in new poetry release: https://github.com/python-poetry/poetry/pull/9547