### PR TITLE
fix tests (outdated upload/download-artifact)

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,9 +11,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out the repository
-              uses: actions/checkout@v2.4.0
+              uses: actions/checkout@v4.2.1
 
             - name: Run Labeler
-              uses: crazy-max/ghaction-github-labeler@v3.1.1
+              uses: crazy-max/ghaction-github-labeler@v5.0.0
               with:
                   skip-delete: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out the repository
-              uses: actions/checkout@v2.4.0
+              uses: actions/checkout@v4.2.1
               with:
                   fetch-depth: 2
 
             - name: Set up Python
-              uses: actions/setup-python@v2.3.2
+              uses: actions/setup-python@v5.2.0
               with:
                   python-version: "3.9"
 
@@ -36,7 +36,7 @@ jobs:
             - name: Detect and tag new version
               id: check-version
               if: steps.check-parent-commit.outputs.sha
-              uses: salsify/action-detect-and-tag-new-version@v2.0.1
+              uses: salsify/action-detect-and-tag-new-version@v2.0.3
               with:
                   version-command: |
                       bash -o pipefail -c "poetry version | awk '{ print \$2 }'"
@@ -51,21 +51,21 @@ jobs:
                   poetry build --ansi
             - name: Publish package on PyPI
               if: steps.check-version.outputs.tag
-              uses: pypa/gh-action-pypi-publish@v1.5.0
+              uses: pypa/gh-action-pypi-publish@v1.10.3
               with:
                   user: __token__
                   password: ${{ secrets.PYPI_TOKEN }}
 
             - name: Publish package on TestPyPI
               if: "! steps.check-version.outputs.tag"
-              uses: pypa/gh-action-pypi-publish@v1.5.0
+              uses: pypa/gh-action-pypi-publish@v1.10.3
               with:
                   user: __token__
                   password: ${{ secrets.TEST_PYPI_TOKEN }}
                   repository_url: https://test.pypi.org/legacy/
 
             - name: Publish the release notes
-              uses: release-drafter/release-drafter@v5.18.1
+              uses: release-drafter/release-drafter@v6.0.0
               with:
                   publish: ${{ steps.check-version.outputs.tag != '' }}
                   tag: ${{ steps.check-version.outputs.tag }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
               uses: actions/upload-artifact@v4.4.1
               with:
                   name: coverage-data
-                  path: ".coverage.*"
+                  path: "/home/runner/work/pytorch-ie/pytorch-ie/.coverage.*"
 
             - name: Upload documentation
               if: matrix.session == 'docs-build'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,10 +31,10 @@ jobs:
 
         steps:
             - name: Check out the repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v4.2.1
 
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v5.2.0
               with:
                   python-version: ${{ matrix.python }}
                   #   cache: pip
@@ -74,7 +74,7 @@ jobs:
                   result = "${{ runner.os }}-{}-{}-pre-commit".format(python, digest[:8])
                   print("::set-output name=result::{}".format(result))
             - name: Restore pre-commit cache
-              uses: actions/cache@v2.1.7
+              uses: actions/cache@v4.1.0
               if: matrix.session == 'pre-commit'
               with:
                   path: ~/.cache/pre-commit
@@ -104,10 +104,10 @@ jobs:
         needs: tests
         steps:
             - name: Check out the repository
-              uses: actions/checkout@v2.4.0
+              uses: actions/checkout@v4.2.1
 
             - name: Set up Python
-              uses: actions/setup-python@v2.3.2
+              uses: actions/setup-python@v5.2.0
               with:
                   python-version: "3.9"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,9 @@ jobs:
             - name: Run Nox
               run: |
                   nox --python=${{ matrix.python }}
+            - name: show files
+              run: |
+                  ls -la
             - name: Upload coverage data
               if: always() && matrix.session == 'tests_not_slow'
               uses: actions/upload-artifact@v4.4.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,14 +86,14 @@ jobs:
                   nox --python=${{ matrix.python }}
             - name: Upload coverage data
               if: always() && matrix.session == 'tests_not_slow'
-              uses: actions/upload-artifact@v2.3.1
+              uses: actions/upload-artifact@v4.4.1
               with:
                   name: coverage-data
                   path: ".coverage.*"
 
             - name: Upload documentation
               if: matrix.session == 'docs-build'
-              uses: actions/upload-artifact@v2.3.1
+              uses: actions/upload-artifact@v4.4.1
               with:
                   name: docs
                   path: docs/_build
@@ -124,7 +124,7 @@ jobs:
                   pipx inject --pip-args=--constraint=$(pwd)/.github/workflows/constraints.txt nox nox-poetry
                   nox --version
             - name: Download coverage data
-              uses: actions/download-artifact@v2.1.0
+              uses: actions/download-artifact@v4.1.8
               with:
                   name: coverage-data
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
                   nox --python=${{ matrix.python }}
             - name: Upload coverage data
               if: always() && matrix.session == 'tests_not_slow'
-              uses: "actions/upload-artifact@v2.3.1"
+              uses: actions/upload-artifact@v2.3.1
               with:
                   name: coverage-data
                   path: ".coverage.*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,21 +84,13 @@ jobs:
             - name: Run Nox
               run: |
                   nox --python=${{ matrix.python }}
-            - name: show files
-              run: |
-                  ls -la
-            - name: shw current directory
-              run: |
-                  pwd
-            - name: show files2
-              run: |
-                  find . -name ".coverage*"
             - name: Upload coverage data
               if: always() && matrix.session == 'tests_not_slow'
               uses: actions/upload-artifact@v4.4.1
               with:
                   name: coverage-data
-                  path: "/home/runner/work/pytorch-ie/pytorch-ie/.coverage.*"
+                  include-hidden-files: true
+                  path: ".coverage.*"
 
             - name: Upload documentation
               if: matrix.session == 'docs-build'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,12 @@ jobs:
             - name: show files
               run: |
                   ls -la
+            - name: shw current directory
+              run: |
+                  pwd
+            - name: show files2
+              run: |
+                  find . -name ".coverage*"
             - name: Upload coverage data
               if: always() && matrix.session == 'tests_not_slow'
               uses: actions/upload-artifact@v4.4.1

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -368,5 +368,3 @@ class Pipeline:
             return documents[0]
         else:
             return documents
-
-        print("REMOVE THIS LINE")

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -368,3 +368,5 @@ class Pipeline:
             return documents[0]
         else:
             return documents
+
+        print("REMOVE THIS LINE")


### PR DESCRIPTION
see https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Note: This also bumps all remaining actions to latest version (except codecov-action because of added token requirement).