### PR TITLE
outsource `PieModelHFHubMixin.load_model_file`

### DIFF
--- a/src/pytorch_ie/auto.py
+++ b/src/pytorch_ie/auto.py
@@ -55,7 +55,7 @@ class AutoModel(PieModelHFHubMixin):
                 local_files_only=local_files_only,
             )
 
-        model.load_weights(model_file, map_location=map_location, strict=strict)
+        model.load_model_file(model_file, map_location=map_location, strict=strict)
 
         return model
 

--- a/src/pytorch_ie/auto.py
+++ b/src/pytorch_ie/auto.py
@@ -33,14 +33,19 @@ class AutoModel(PieModelHFHubMixin):
         Overwrite this method in case you wish to initialize your model in a different way.
         """
 
+        config = (config or {}).copy()
+        config.update(model_kwargs)
+        class_name = config.pop(cls.config_type_key)
+        clazz = PyTorchIEModel.by_name(class_name)
+        model = clazz(**config)
+
         """Load Pytorch pretrained weights and return the loaded model."""
         if os.path.isdir(model_id):
-            print("Loading weights from local directory")
-            model_file = os.path.join(model_id, PYTORCH_WEIGHTS_NAME)
+            model_file = os.path.join(model_id, model.weights_file_name)
         else:
             model_file = hf_hub_download(
                 repo_id=model_id,
-                filename=PYTORCH_WEIGHTS_NAME,
+                filename=model.weights_file_name,
                 revision=revision,
                 cache_dir=cache_dir,
                 force_download=force_download,
@@ -50,15 +55,7 @@ class AutoModel(PieModelHFHubMixin):
                 local_files_only=local_files_only,
             )
 
-        config = (config or {}).copy()
-        config.update(model_kwargs)
-        class_name = config.pop(cls.config_type_key)
-        clazz = PyTorchIEModel.by_name(class_name)
-        model = clazz(**config)
-
-        state_dict = torch.load(model_file, map_location=torch.device(map_location))
-        model.load_state_dict(state_dict, strict=strict)  # type: ignore
-        model.eval()  # type: ignore
+        model.load_weights(model_file, map_location=map_location, strict=strict)
 
         return model
 

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -351,6 +351,7 @@ TModel = TypeVar("TModel", bound="PieModelHFHubMixin")
 class PieModelHFHubMixin(PieBaseHFHubMixin):
     config_name = MODEL_CONFIG_NAME
     config_type_key = MODEL_CONFIG_TYPE_KEY
+    weights_file_name = PYTORCH_WEIGHTS_NAME
 
     """
     Implementation of [`ModelHubMixin`] to provide model Hub upload/download capabilities to PyTorch models. The model
@@ -389,7 +390,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
     def _save_pretrained(self, save_directory: Path) -> None:
         """Save weights from a Pytorch model to a local directory."""
         model_to_save = self.module if hasattr(self, "module") else self  # type: ignore
-        torch.save(model_to_save.state_dict(), save_directory / PYTORCH_WEIGHTS_NAME)
+        torch.save(model_to_save.state_dict(), save_directory / self.weights_file_name)
 
     def load_weights(
         self, model_file: str, map_location: str = "cpu", strict: bool = False
@@ -418,11 +419,11 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         """Load Pytorch pretrained weights and return the loaded model."""
         if os.path.isdir(model_id):
             logger.info("Loading weights from local directory")
-            model_file = os.path.join(model_id, PYTORCH_WEIGHTS_NAME)
+            model_file = os.path.join(model_id, cls.weights_file_name)
         else:
             model_file = hf_hub_download(
                 repo_id=model_id,
-                filename=PYTORCH_WEIGHTS_NAME,
+                filename=cls.weights_file_name,
                 revision=revision,
                 cache_dir=cache_dir,
                 force_download=force_download,

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -392,7 +392,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         model_to_save = self.module if hasattr(self, "module") else self  # type: ignore
         torch.save(model_to_save.state_dict(), save_directory / self.weights_file_name)
 
-    def load_weights(
+    def load_model_file(
         self, model_file: str, map_location: str = "cpu", strict: bool = False
     ) -> None:
         state_dict = torch.load(model_file, map_location=torch.device(map_location))
@@ -440,7 +440,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
                 local_files_only=local_files_only,
             )
 
-        model.load_weights(model_file, map_location=map_location, strict=strict)
+        model.load_model_file(model_file, map_location=map_location, strict=strict)
 
         return model
 

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -396,8 +396,8 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         self, model_file: str, map_location: str = "cpu", strict: bool = False
     ) -> None:
         state_dict = torch.load(model_file, map_location=torch.device(map_location))
-        model.load_state_dict(state_dict, strict=strict)  # type: ignore
-        model.eval()  # type: ignore
+        self.load_state_dict(state_dict, strict=strict)  # type: ignore
+        self.eval()  # type: ignore
 
     @classmethod
     def _from_pretrained(

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -416,14 +416,21 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         config: Optional[dict] = None,
         **model_kwargs,
     ) -> TModel:
+
+        config = (config or {}).copy()
+        config.update(model_kwargs)
+        if cls.config_type_key is not None:
+            config.pop(cls.config_type_key)
+        model = cls(**config)
+
         """Load Pytorch pretrained weights and return the loaded model."""
         if os.path.isdir(model_id):
             logger.info("Loading weights from local directory")
-            model_file = os.path.join(model_id, cls.weights_file_name)
+            model_file = os.path.join(model_id, model.weights_file_name)
         else:
             model_file = hf_hub_download(
                 repo_id=model_id,
-                filename=cls.weights_file_name,
+                filename=model.weights_file_name,
                 revision=revision,
                 cache_dir=cache_dir,
                 force_download=force_download,
@@ -432,12 +439,6 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
                 token=token,
                 local_files_only=local_files_only,
             )
-
-        config = (config or {}).copy()
-        config.update(model_kwargs)
-        if cls.config_type_key is not None:
-            config.pop(cls.config_type_key)
-        model = cls(**config)
 
         model.load_weights(model_file, map_location=map_location, strict=strict)
 

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -387,10 +387,10 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
     ```
     """
 
-    def _save_pretrained(self, save_directory: Path) -> None:
+    def save_model_file(self, model_file: str) -> None:
         """Save weights from a Pytorch model to a local directory."""
         model_to_save = self.module if hasattr(self, "module") else self  # type: ignore
-        torch.save(model_to_save.state_dict(), save_directory / self.weights_file_name)
+        torch.save(model_to_save.state_dict(), model_file)
 
     def load_model_file(
         self, model_file: str, map_location: str = "cpu", strict: bool = False
@@ -398,6 +398,10 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         state_dict = torch.load(model_file, map_location=torch.device(map_location))
         self.load_state_dict(state_dict, strict=strict)  # type: ignore
         self.eval()  # type: ignore
+
+    def _save_pretrained(self, save_directory: Path) -> None:
+        """Save weights from a Pytorch model to a local directory."""
+        self.save_model_file(str(save_directory / self.weights_file_name))
 
     @classmethod
     def _from_pretrained(

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -388,6 +388,13 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         model_to_save = self.module if hasattr(self, "module") else self  # type: ignore
         torch.save(model_to_save.state_dict(), save_directory / PYTORCH_WEIGHTS_NAME)
 
+    def load_weights(
+        self, model_file: str, map_location: str = "cpu", strict: bool = False
+    ) -> None:
+        state_dict = torch.load(model_file, map_location=torch.device(map_location))
+        model.load_state_dict(state_dict, strict=strict)  # type: ignore
+        model.eval()  # type: ignore
+
     @classmethod
     def _from_pretrained(
         cls: Type[T],
@@ -428,9 +435,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
             config.pop(cls.config_type_key)
         model = cls(**config)
 
-        state_dict = torch.load(model_file, map_location=torch.device(map_location))
-        model.load_state_dict(state_dict, strict=strict)  # type: ignore
-        model.eval()  # type: ignore
+        model.load_weights(model_file, map_location=map_location, strict=strict)
 
         return model
 

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -345,6 +345,9 @@ class PieBaseHFHubMixin:
         return cls(**config)
 
 
+TModel = TypeVar("TModel", bound="PieModelHFHubMixin")
+
+
 class PieModelHFHubMixin(PieBaseHFHubMixin):
     config_name = MODEL_CONFIG_NAME
     config_type_key = MODEL_CONFIG_TYPE_KEY
@@ -397,7 +400,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
 
     @classmethod
     def _from_pretrained(
-        cls: Type[T],
+        cls: Type[TModel],
         *,
         model_id: str,
         revision: Optional[str],
@@ -411,7 +414,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         strict: bool = False,
         config: Optional[dict] = None,
         **model_kwargs,
-    ) -> T:
+    ) -> TModel:
         """Load Pytorch pretrained weights and return the loaded model."""
         if os.path.isdir(model_id):
             logger.info("Loading weights from local directory")
@@ -440,6 +443,9 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         return model
 
 
+TTaskModule = TypeVar("TTaskModule", bound="PieTaskModuleHFHubMixin")
+
+
 class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
     config_name = TASKMODULE_CONFIG_NAME
     config_type_key = TASKMODULE_CONFIG_TYPE_KEY
@@ -452,7 +458,7 @@ class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
 
     @classmethod
     def _from_pretrained(
-        cls: Type[T],
+        cls: Type[TTaskModule],
         *,
         model_id: str,
         revision: Optional[str],
@@ -466,7 +472,7 @@ class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
         strict: bool = False,
         config: Optional[dict] = None,
         **taskmodule_kwargs,
-    ) -> T:
+    ) -> TTaskModule:
         config = (config or {}).copy()
         config.update(taskmodule_kwargs)
         if cls.config_type_key is not None:


### PR DESCRIPTION
to make it overwritable. This also:
 - fixes some typing
 - parametrizes `weights_file_name`
 - for consistence, also adds `save_model_file`