### PR TITLE
half and mixed precision inference

### DIFF
--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -72,6 +72,7 @@ class Pipeline:
         # reflected in typing of PyTorch.
         self.model: PyTorchIEModel = model.to(self.device)  # type: ignore
         if half_precision_model:
+            # TODO: use torch.get_autocast_dtype(self.device.type) when available
             self.model = self.model.to(dtype=self.get_autocast_dtype())
 
         self.call_count = 0

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -339,7 +339,7 @@ class Pipeline:
                 run. If set to :obj:`True`, only the first two model inputs will be processed.
             half_precision_ops (:obj:`bool`, `optional`, defaults to :obj:`False`): Whether or not to use half
                 precision operations. If set to :obj:`True`, the model will be run with half precision operations
-                via :obj:`torch.cuda.amp.autocast`.
+                via :obj:`torch.autocast`.
             batch_size (:obj:`int`, `optional`, defaults to :obj:`1`): The batch size to use for the dataloader. If not
                 provided, a batch size of 1 will be used.
             num_workers (:obj:`int`, `optional`, defaults to :obj:`8`): The number of workers to use for the dataloader.

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -337,11 +337,9 @@ class Pipeline:
                 during inference.
             fast_dev_run (:obj:`bool`, `optional`, defaults to :obj:`False`): Whether or not to run a fast development
                 run. If set to :obj:`True`, only the first two model inputs will be processed.
-            half_precision_model (:obj:`bool`, `optional`, defaults to :obj:`False`):
-                Whether or not to use half precision model. If set to :obj:`True`, the model
-                will be cast to :obj:`torch.float16` on supported devices. This can reduce the
-                memory consumption and improve the inference speed, but may lead to numerical
-                instability.
+            half_precision_ops (:obj:`bool`, `optional`, defaults to :obj:`False`): Whether or not to use half
+                precision operations. If set to :obj:`True`, the model will be run with half precision operations
+                via :obj:`torch.cuda.amp.autocast`.
             batch_size (:obj:`int`, `optional`, defaults to :obj:`1`): The batch size to use for the dataloader. If not
                 provided, a batch size of 1 will be used.
             num_workers (:obj:`int`, `optional`, defaults to :obj:`8`): The number of workers to use for the dataloader.

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -230,7 +230,7 @@ class Pipeline:
         **preprocess_parameters: Dict,
     ) -> Sequence[TaskEncoding]:
         """
-        Preprocess will take the `input_` of a specific pipeline and return a dictionnary of everything necessary for
+        Preprocess will take the `input_` of a specific pipeline and return a dictionary of everything necessary for
         `_forward` to run properly. It should contain at least one tensor, but might have arbitrary other items.
         """
 
@@ -248,7 +248,7 @@ class Pipeline:
         self, input_tensors: Tuple[Dict[str, Tensor], Any, Any, Any], **forward_parameters: Dict
     ) -> Dict:
         """
-        _forward will receive the prepared dictionnary from `preprocess` and run it on the model. This method might
+        _forward will receive the prepared dictionary from `preprocess` and run it on the model. This method might
         involve the GPU or the CPU and should be agnostic to it. Isolating this function is the reason for `preprocess`
         and `postprocess` to exist, so that the hot path, this method generally can run as fast as possible.
 
@@ -325,7 +325,7 @@ class Pipeline:
 
                 1. Encode the documents
                 2. Run the model forward pass(es) on the encodings
-                3. Combine the model outputs with the inputs encodings and integrate them back into the documents
+                3. Combine the model outputs with the input encodings and integrate them back into the documents
 
         Args:
             documents (:obj:`Union[Document, Sequence[Document]]`): The documents to process. If a single document is

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -46,6 +46,10 @@ class Pipeline:
             The device to run the pipeline on. This can be a CPU device (:obj:`"cpu"`), a GPU
             device (:obj:`"cuda"`) or a specific GPU device (:obj:`"cuda:X"`, where :obj:`X`
             is the index of the GPU).
+        half_precision_model (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether or not to use half precision model. This can be set to :obj:`True` to reduce
+            the memory usage of the model. If set to :obj:`True`, the model will be cast to
+            :obj:`torch.float16` on supported devices.
     """
 
     default_input_names = None
@@ -333,6 +337,11 @@ class Pipeline:
                 during inference.
             fast_dev_run (:obj:`bool`, `optional`, defaults to :obj:`False`): Whether or not to run a fast development
                 run. If set to :obj:`True`, only the first two model inputs will be processed.
+            half_precision_model (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether or not to use half precision model. If set to :obj:`True`, the model
+                will be cast to :obj:`torch.float16` on supported devices. This can reduce the
+                memory consumption and improve the inference speed, but may lead to numerical
+                instability.
             batch_size (:obj:`int`, `optional`, defaults to :obj:`1`): The batch size to use for the dataloader. If not
                 provided, a batch size of 1 will be used.
             num_workers (:obj:`int`, `optional`, defaults to :obj:`8`): The number of workers to use for the dataloader.

--- a/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
@@ -182,7 +182,7 @@ class SimpleTransformerTextClassificationTaskModule(TaskModuleType):
         logits = model_output["logits"]
 
         # convert the logits to "probabilities"
-        probabilities = logits.softmax(dim=-1).detach().cpu().numpy()
+        probabilities = logits.softmax(dim=-1).detach().cpu().float().numpy()
 
         # get the max class index per example
         max_label_ids = np.argmax(probabilities, axis=-1)

--- a/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -556,7 +556,7 @@ class TransformerRETextClassificationTaskModule(TaskModuleType, ChangesTokenizer
         logits = model_output["logits"]
 
         output_label_probs = logits.sigmoid() if self.multi_label else logits.softmax(dim=-1)
-        output_label_probs = output_label_probs.detach().cpu().numpy()
+        output_label_probs = output_label_probs.detach().cpu().float().numpy()
 
         unbatched_output = []
         if self.multi_label:

--- a/src/pytorch_ie/taskmodules/transformer_span_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_span_classification.py
@@ -227,7 +227,7 @@ class TransformerSpanClassificationTaskModule(TaskModuleType):
 
     def unbatch_output(self, model_output: ModelOutputType) -> Sequence[TaskOutputType]:
         logits = model_output["logits"]
-        probs = F.softmax(logits, dim=-1).detach().cpu().numpy()
+        probs = F.softmax(logits, dim=-1).detach().cpu().float().numpy()
         label_ids = torch.argmax(logits, dim=-1).detach().cpu().numpy()
 
         start_indices = model_output["start_indices"].detach().cpu().numpy()

--- a/src/pytorch_ie/taskmodules/transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_text_classification.py
@@ -196,7 +196,7 @@ class TransformerTextClassificationTaskModule(TaskModuleType):
         logits = model_output["logits"]
 
         output_label_probs = logits.sigmoid() if self.multi_label else logits.softmax(dim=-1)
-        output_label_probs = output_label_probs.detach().cpu().numpy()
+        output_label_probs = output_label_probs.detach().cpu().float().numpy()
 
         if self.multi_label:
             raise NotImplementedError()

--- a/src/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -290,7 +290,7 @@ class TransformerTokenClassificationTaskModule(TaskModuleType):
 
     def unbatch_output(self, model_output: ModelOutputType) -> Sequence[TaskOutputType]:
         logits = model_output["logits"]
-        probabilities = F.softmax(logits, dim=-1).detach().cpu().numpy()
+        probabilities = F.softmax(logits, dim=-1).detach().cpu().float().numpy()
         indices = torch.argmax(logits, dim=-1).detach().cpu().numpy()
         tags = [[self.id_to_label[e] for e in b] for b in indices]
         return [{"tags": t, "probabilities": p} for t, p in zip(tags, probabilities)]


### PR DESCRIPTION
This PR implements half and mixed precision inference by adding the following boolean parameters to the `Pipeline`:
- `half_precision_model`:  Whether or not to use half precision model. If set to `True`, the model will be cast to half precision on supported devices (`torch.float16` on `cuda` and `torch.bfloat16` on `cpu` for now, following `torch.get_autocast_dtype()`). This can reduce the memory consumption and improve the inference speed, but may lead to numerical instability.
- `half_precision_ops`: Whether or not to use half precision operations. If set to `True`, the model will be run with half precision operations via [torch.autocast](https://pytorch.org/docs/stable/amp.html#torch.autocast).

Since `torch.float16` can not be natively converted to `numpy`, this PR adds `float()` casting to several model outputs (probabilities) before calling `.numpy()`. in `unbatch_output()` of several taskmodules. Also, this fixes some spelling mistakes in the `Pipeline` documentation.

TODO:
 - [x] test in downstream setup, e.g. inference on drugprot. 
   - Outcome: effective for large batch sizes (e.g. 512)

| batch_size | half_precision_model | half_precision_ops | inference_time | speed_up |
|------------|----------------------|--------------------|----------------|----------|
| 32         | True                 | True               | 32.8           | 2.4      |
| 32         | True                 | False              | 26.4           | 3.0      |
| 32         | False                | True               | 28.8           | 2.7      |
| 32         | False                | False              | 79.0           | 1.0      |
| 256        | True                 | True               | 23.6           | 3.5      |
| 256        | True                 | False              | 21.2           | 3.9      |
| 256        | False                | True               | 23.7           | 3.5      |
| 256        | False                | False              | 83.6           | 1.0      |
| 512        | True                 | True               | 24.4           | 3.7      |
| 512        | True                 | False              | 22.7           | 4.0      |
| 512        | False                | True               | 25.0           | 3.6      |
| 512        | False                | False              | 90.7           | 1.0      |
| 1024       | True                 | True               | 26.9           | 3.7      |
| 1024       | True                 | False              | 23.7           | 4.1      |
| 1024       | False                | True               | 26.7           | 3.7      |
| 1024       | False                | False              | 98.3           | 1.0      |
  