### PR TITLE
implement `ConfusionMatrix` document metric

### DIFF
--- a/src/pytorch_ie/metrics/__init__.py
+++ b/src/pytorch_ie/metrics/__init__.py
@@ -1,3 +1,4 @@
+from .confusion_matrix import ConfusionMatrix
 from .f1 import F1Metric
 
-__all__ = ["F1Metric"]
+__all__ = ["F1Metric", "ConfusionMatrix"]

--- a/src/pytorch_ie/metrics/confusion_matrix.py
+++ b/src/pytorch_ie/metrics/confusion_matrix.py
@@ -68,7 +68,7 @@ class ConfusionMatrix(DocumentMetric):
             base2pred[base_ann].append(ann)
 
         # (gold_label, pred_label) -> count
-        counts = defaultdict(int)
+        counts: Dict[Tuple[str, str], int] = defaultdict(int)
         for base_ann in set(base2gold) | set(base2pred):
             gold_labels = [getattr(ann, self.label_field) for ann in base2gold[base_ann]]
             pred_labels = [getattr(ann, self.label_field) for ann in base2pred[base_ann]]

--- a/src/pytorch_ie/metrics/confusion_matrix.py
+++ b/src/pytorch_ie/metrics/confusion_matrix.py
@@ -102,8 +102,8 @@ class ConfusionMatrix(DocumentMetric):
     def _compute(self) -> Dict[str, Dict[str, int]]:
 
         res = defaultdict(dict)
-        for (gold_label, pred_label), count in self.counts.items():
-            res[gold_label][pred_label] = count
+        for gold_label, pred_label in sorted(self.counts):
+            res[gold_label][pred_label] = self.counts[(gold_label, pred_label)]
 
         if self.show_as_markdown:
             logger.info(f"\n{self.layer}:\n{pd.DataFrame(res).fillna(0).T.to_markdown()}")

--- a/src/pytorch_ie/metrics/confusion_matrix.py
+++ b/src/pytorch_ie/metrics/confusion_matrix.py
@@ -1,0 +1,110 @@
+import logging
+from collections import defaultdict
+from typing import Callable, Dict, Optional, Tuple, Union
+
+import pandas as pd
+
+from pytorch_ie.core import Annotation, Document, DocumentMetric
+from pytorch_ie.utils.hydra import resolve_target
+
+logger = logging.getLogger(__name__)
+
+
+class ConfusionMatrix(DocumentMetric):
+    """Computes the confusion matrix for a given annotation layer that contains labeled annotations.
+
+    Args:
+        layer: The layer to compute the confusion matrix for.
+        label_field: The field to use for the label. Defaults to "label".
+        show_as_markdown: If True, logs the confusion matrix as markdown on the console when calling compute().
+        annotation_processor: A callable that processes the annotations before calculating the confusion matrix.
+    """
+
+    def __init__(
+        self,
+        layer: str,
+        label_field: str = "label",
+        show_as_markdown: bool = False,
+        na_label: str = "NA",
+        annotation_processor: Optional[Union[Callable[[Annotation], Annotation], str]] = None,
+    ):
+        super().__init__()
+        self.layer = layer
+        self.label_field = label_field
+        self.na_label = na_label
+        self.show_as_markdown = show_as_markdown
+        if isinstance(annotation_processor, str):
+            annotation_processor = resolve_target(annotation_processor)
+        self.annotation_processor = annotation_processor
+
+    def reset(self):
+        self.counts: Dict[Tuple[str, str], int] = defaultdict(int)
+
+    def calculate_counts(
+        self,
+        document: Document,
+        annotation_filter: Optional[Callable[[Annotation], bool]] = None,
+        annotation_processor: Optional[Callable[[Annotation], Annotation]] = None,
+    ) -> Dict[Tuple[str, str], int]:
+        annotation_processor = annotation_processor or (lambda ann: ann)
+        annotation_filter = annotation_filter or (lambda ann: True)
+        predicted_annotations = {
+            annotation_processor(ann)
+            for ann in document[self.layer].predictions
+            if annotation_filter(ann)
+        }
+        gold_annotations = {
+            annotation_processor(ann) for ann in document[self.layer] if annotation_filter(ann)
+        }
+        base2gold = defaultdict(list)
+        for ann in gold_annotations:
+            base_ann_kwargs = {self.label_field: "DUMMY_LABEL"}
+            base_ann = ann.copy(**base_ann_kwargs)
+            base2gold[base_ann].append(ann)
+        base2pred = defaultdict(list)
+        for ann in predicted_annotations:
+            base_ann_kwargs = {self.label_field: "DUMMY_LABEL"}
+            base_ann = ann.copy(**base_ann_kwargs)
+            base2pred[base_ann].append(ann)
+
+        # (gold_label, pred_label) -> count
+        counts = defaultdict(int)
+        for base_ann in set(base2gold) | set(base2pred):
+            gold_labels = [getattr(ann, self.label_field) for ann in base2gold[base_ann]]
+            pred_labels = [getattr(ann, self.label_field) for ann in base2pred[base_ann]]
+
+            # TODO: is this logic correct?
+            if len(gold_labels) == 0:
+                gold_labels.append(self.na_label)
+            if len(pred_labels) == 0:
+                pred_labels.append(self.na_label)
+
+            if len(gold_labels) > 1:
+                raise ValueError("The base annotation has multiple gold labels.")
+
+            for gold_label in gold_labels:
+                for pred_label in pred_labels:
+                    counts[(gold_label, pred_label)] += 1
+
+        return counts
+
+    def add_counts(self, counts: Dict[Tuple[str, str], int]):
+        for key, value in counts.items():
+            self.counts[key] += value
+
+    def _update(self, document: Document):
+        new_counts = self.calculate_counts(
+            document=document,
+            annotation_processor=self.annotation_processor,
+        )
+        self.add_counts(new_counts)
+
+    def _compute(self) -> Dict[str, Dict[str, int]]:
+
+        res = defaultdict(dict)
+        for (gold_label, pred_label), count in self.counts.items():
+            res[gold_label][pred_label] = count
+
+        if self.show_as_markdown:
+            logger.info(f"\n{self.layer}:\n{pd.DataFrame(res).fillna(0).T.to_markdown()}")
+        return res

--- a/src/pytorch_ie/metrics/confusion_matrix.py
+++ b/src/pytorch_ie/metrics/confusion_matrix.py
@@ -73,6 +73,15 @@ class ConfusionMatrix(DocumentMetric):
             gold_labels = [getattr(ann, self.label_field) for ann in base2gold[base_ann]]
             pred_labels = [getattr(ann, self.label_field) for ann in base2pred[base_ann]]
 
+            if self.na_label in gold_labels:
+                raise ValueError(
+                    f"The gold annotation has the na_label='{self.na_label}' as label. Set a different na_label."
+                )
+            if self.na_label in pred_labels:
+                raise ValueError(
+                    f"The predicted annotation has the na_label='{self.na_label}' as label. Set a different na_label."
+                )
+
             # TODO: is this logic correct?
             if len(gold_labels) == 0:
                 gold_labels.append(self.na_label)

--- a/src/pytorch_ie/metrics/confusion_matrix.py
+++ b/src/pytorch_ie/metrics/confusion_matrix.py
@@ -110,7 +110,7 @@ class ConfusionMatrix(DocumentMetric):
 
     def _compute(self) -> Dict[str, Dict[str, int]]:
 
-        res: Dict[Tuple[str, str], int] = defaultdict(dict)
+        res: Dict[str, Dict[str, int]] = defaultdict(dict)
         for gold_label, pred_label in sorted(self.counts):
             res[gold_label][pred_label] = self.counts[(gold_label, pred_label)]
 

--- a/src/pytorch_ie/metrics/confusion_matrix.py
+++ b/src/pytorch_ie/metrics/confusion_matrix.py
@@ -115,5 +115,16 @@ class ConfusionMatrix(DocumentMetric):
             res[gold_label][pred_label] = self.counts[(gold_label, pred_label)]
 
         if self.show_as_markdown:
-            logger.info(f"\n{self.layer}:\n{pd.DataFrame(res).fillna(0).T.to_markdown()}")
+            res_df = pd.DataFrame(res).fillna(0)
+            # sort index and columns
+            columns_sorted = sorted([col for col in res_df.columns if col != self.na_label])
+            if self.na_label in res_df.columns:
+                columns_sorted = columns_sorted + [self.na_label]
+            index_sorted = sorted([idx for idx in res_df.index if idx != self.na_label])
+            if self.na_label in res_df.index:
+                index_sorted = index_sorted + [self.na_label]
+            res_df_sorted = res_df.loc[index_sorted, columns_sorted]
+
+            # show as markdown: index is gold, columns is prediction
+            logger.info(f"\n{self.layer}:\n{res_df_sorted.T.to_markdown()}")
         return res

--- a/src/pytorch_ie/metrics/confusion_matrix.py
+++ b/src/pytorch_ie/metrics/confusion_matrix.py
@@ -128,17 +128,26 @@ class ConfusionMatrix(DocumentMetric):
             res[gold_label][pred_label] = self.counts[(gold_label, pred_label)]
 
         if self.show_as_markdown:
-            # index is prediction, columns is gold TODO: really, is this correct?
             res_df = pd.DataFrame(res).fillna(0)
-            # sort index and columns
-            gold_labels_sorted = sorted([col for col in res_df.columns if col != self.fp_label])
-            if self.fn_label in res_df.columns:
+            # index is prediction, columns is gold TODO: really, is this correct?
+            gold_labels = res_df.columns
+            pred_labels = res_df.index
+
+            # re-arrange index and columns: sort and put fp_label and fn_label at the end
+            gold_labels_sorted = sorted(
+                [gold_label for gold_label in gold_labels if gold_label != self.fp_label]
+            )
+            # re-add fp_label at the end, if it was in the gold labels
+            if self.fp_label in gold_labels:
                 gold_labels_sorted = gold_labels_sorted + [self.fp_label]
-            pred_labels_sorted = sorted([idx for idx in res_df.index if idx != self.fn_label])
-            if self.fn_label in res_df.index:
+            pred_labels_sorted = sorted(
+                [pred_label for pred_label in pred_labels if pred_label != self.fn_label]
+            )
+            # re-add fn_label at the end, if it was in the pred labels
+            if self.fn_label in pred_labels:
                 pred_labels_sorted = pred_labels_sorted + [self.fn_label]
             res_df_sorted = res_df.loc[pred_labels_sorted, gold_labels_sorted]
 
-            # transpose and show as markdown: index is gold, columns is prediction
+            # transpose and show as markdown: index is now gold, columns is prediction
             logger.info(f"\n{self.layer}:\n{res_df_sorted.T.to_markdown()}")
         return res

--- a/src/pytorch_ie/metrics/confusion_matrix.py
+++ b/src/pytorch_ie/metrics/confusion_matrix.py
@@ -128,7 +128,7 @@ class ConfusionMatrix(DocumentMetric):
             res[gold_label][pred_label] = self.counts[(gold_label, pred_label)]
 
         if self.show_as_markdown:
-            # index is prediction, columns is gold
+            # index is prediction, columns is gold TODO: really, is this correct?
             res_df = pd.DataFrame(res).fillna(0)
             # sort index and columns
             gold_labels_sorted = sorted([col for col in res_df.columns if col != self.fp_label])

--- a/src/pytorch_ie/metrics/confusion_matrix.py
+++ b/src/pytorch_ie/metrics/confusion_matrix.py
@@ -101,7 +101,7 @@ class ConfusionMatrix(DocumentMetric):
 
     def _compute(self) -> Dict[str, Dict[str, int]]:
 
-        res = defaultdict(dict)
+        res: Dict[Tuple[str, str], int] = defaultdict(dict)
         for gold_label, pred_label in sorted(self.counts):
             res[gold_label][pred_label] = self.counts[(gold_label, pred_label)]
 

--- a/tests/metrics/test_confusion_matrix.py
+++ b/tests/metrics/test_confusion_matrix.py
@@ -50,11 +50,11 @@ def test_confusion_matrix(documents):
     assert dict(metric.counts) == {
         ("animal", "animal"): 1,
         ("animal", "cat"): 1,
-        ("MISSED", "company"): 1,
+        ("FALSE_POSITIVE", "company"): 1,
         ("company", "company"): 1,
     }
     assert metric.compute() == {
         "animal": {"animal": 1, "cat": 1},
-        "MISSED": {"company": 1},
+        "FALSE_POSITIVE": {"company": 1},
         "company": {"company": 1},
     }

--- a/tests/metrics/test_confusion_matrix.py
+++ b/tests/metrics/test_confusion_matrix.py
@@ -50,11 +50,11 @@ def test_confusion_matrix(documents):
     assert dict(metric.counts) == {
         ("animal", "animal"): 1,
         ("animal", "cat"): 1,
-        ("FALSE_POSITIVE", "company"): 1,
+        ("UNDETECTED", "company"): 1,
         ("company", "company"): 1,
     }
     assert metric.compute() == {
         "animal": {"animal": 1, "cat": 1},
-        "FALSE_POSITIVE": {"company": 1},
+        "UNDETECTED": {"company": 1},
         "company": {"company": 1},
     }

--- a/tests/metrics/test_confusion_matrix.py
+++ b/tests/metrics/test_confusion_matrix.py
@@ -50,11 +50,11 @@ def test_confusion_matrix(documents):
     assert dict(metric.counts) == {
         ("animal", "animal"): 1,
         ("animal", "cat"): 1,
-        ("NA", "company"): 1,
+        ("MISSED", "company"): 1,
         ("company", "company"): 1,
     }
     assert metric.compute() == {
         "animal": {"animal": 1, "cat": 1},
-        "NA": {"company": 1},
+        "MISSED": {"company": 1},
         "company": {"company": 1},
     }

--- a/tests/metrics/test_confusion_matrix.py
+++ b/tests/metrics/test_confusion_matrix.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+
+import pytest
+
+from pytorch_ie.annotations import LabeledSpan
+from pytorch_ie.core import AnnotationLayer, annotation_field
+from pytorch_ie.documents import TextBasedDocument
+from pytorch_ie.metrics import ConfusionMatrix
+
+
+@pytest.fixture
+def documents():
+    @dataclass
+    class TextDocumentWithEntities(TextBasedDocument):
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+
+    # a test sentence with two entities
+    doc1 = TextDocumentWithEntities(
+        text="The quick brown fox jumps over the lazy dog.",
+    )
+    doc1.entities.append(LabeledSpan(start=4, end=19, label="animal"))
+    doc1.entities.append(LabeledSpan(start=35, end=43, label="animal"))
+    assert str(doc1.entities[0]) == "quick brown fox"
+    assert str(doc1.entities[1]) == "lazy dog"
+
+    # a second test sentence with a different text and a single entity (a company)
+    doc2 = TextDocumentWithEntities(text="Apple is a great company.")
+    doc2.entities.append(LabeledSpan(start=0, end=5, label="company"))
+    assert str(doc2.entities[0]) == "Apple"
+
+    documents = [doc1, doc2]
+
+    # add predictions
+    # correct
+    documents[0].entities.predictions.append(LabeledSpan(start=4, end=19, label="animal"))
+    # wrong label
+    documents[0].entities.predictions.append(LabeledSpan(start=35, end=43, label="cat"))
+    # correct
+    documents[1].entities.predictions.append(LabeledSpan(start=0, end=5, label="company"))
+    # wrong span
+    documents[1].entities.predictions.append(LabeledSpan(start=10, end=15, label="company"))
+
+    return documents
+
+
+def test_confusion_matrix(documents):
+    metric = ConfusionMatrix(layer="entities")
+    metric(documents)
+    # (gold_label, predicted_label): count
+    assert dict(metric.counts) == {
+        ("animal", "animal"): 1,
+        ("animal", "cat"): 1,
+        ("NA", "company"): 1,
+        ("company", "company"): 1,
+    }
+    assert metric.compute() == {
+        "animal": {"animal": 1, "cat": 1},
+        "NA": {"company": 1},
+        "company": {"company": 1},
+    }


### PR DESCRIPTION
This PR implements the document metric `ConfusionMatrix`. From the docstring:
```
Computes the confusion matrix for a given annotation layer that contains labeled annotations.

    Args:
        layer: The layer to compute the confusion matrix for.
        label_field: The field to use for the label. Defaults to "label".
        unassignable_label: The label to use for false negative annotations. Defaults to "UNASSIGNABLE".
        undetected_label: The label to use for false positive annotations. Defaults to "UNDETECTED".
        strict: If True, raises an error if a base annotation has multiple gold labels. If False, logs a warning.
        show_as_markdown: If True, logs the confusion matrix as markdown on the console when calling compute().
        annotation_processor: A callable that processes the annotations before calculating the confusion matrix.

```

Notes:
 - Can handle multiple predicted labels for the same base annotation, but not multiple gold labels.
 - Inserts placeholder `UNDETECTED` for gold labels without a prediction and `UNASSIGNABLE` for predictions without a gold label.