### PR TITLE
nested config update in `_from_pretrained` and `_from_config`

### DIFF
--- a/src/pytorch_ie/auto.py
+++ b/src/pytorch_ie/auto.py
@@ -10,6 +10,7 @@ from pytorch_ie.core import PyTorchIEModel, TaskModule
 from pytorch_ie.core.hf_hub_mixin import (
     PieModelHFHubMixin,
     PieTaskModuleHFHubMixin,
+    TOverride,
     dict_update_nested,
 )
 from pytorch_ie.pipeline import Pipeline
@@ -31,6 +32,7 @@ class AutoModel(PieModelHFHubMixin):
         map_location: str = "cpu",
         strict: bool = False,
         config: Optional[dict] = None,
+        config_override: Optional[TOverride] = None,
         **model_kwargs,
     ) -> PyTorchIEModel:
         """
@@ -38,7 +40,7 @@ class AutoModel(PieModelHFHubMixin):
         """
 
         config = (config or {}).copy()
-        dict_update_nested(config, model_kwargs)
+        dict_update_nested(config, model_kwargs, override=config_override)
         class_name = config.pop(cls.config_type_key)
         clazz = PyTorchIEModel.by_name(class_name)
         model = clazz(**config)
@@ -88,6 +90,7 @@ class AutoTaskModule(PieTaskModuleHFHubMixin):
         map_location: str = "cpu",
         strict: bool = False,
         config: Optional[dict] = None,
+        config_override: Optional[TOverride] = None,
         **taskmodule_kwargs,
     ) -> TaskModule:
         config = (config or {}).copy()

--- a/src/pytorch_ie/auto.py
+++ b/src/pytorch_ie/auto.py
@@ -7,7 +7,11 @@ from huggingface_hub.constants import PYTORCH_WEIGHTS_NAME
 from huggingface_hub.file_download import hf_hub_download
 
 from pytorch_ie.core import PyTorchIEModel, TaskModule
-from pytorch_ie.core.hf_hub_mixin import PieModelHFHubMixin, PieTaskModuleHFHubMixin
+from pytorch_ie.core.hf_hub_mixin import (
+    PieModelHFHubMixin,
+    PieTaskModuleHFHubMixin,
+    dict_update_nested,
+)
 from pytorch_ie.pipeline import Pipeline
 
 
@@ -34,7 +38,7 @@ class AutoModel(PieModelHFHubMixin):
         """
 
         config = (config or {}).copy()
-        config.update(model_kwargs)
+        dict_update_nested(config, model_kwargs)
         class_name = config.pop(cls.config_type_key)
         clazz = PyTorchIEModel.by_name(class_name)
         model = clazz(**config)
@@ -87,7 +91,7 @@ class AutoTaskModule(PieTaskModuleHFHubMixin):
         **taskmodule_kwargs,
     ) -> TaskModule:
         config = (config or {}).copy()
-        config.update(taskmodule_kwargs)
+        dict_update_nested(config, taskmodule_kwargs)
         class_name = config.pop(cls.config_type_key)
         clazz: Type[TaskModule] = TaskModule.by_name(class_name)
         taskmodule = clazz(**config)

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -363,7 +363,7 @@ class PieBaseHFHubMixin:
                 Additional keyword arguments passed along to the specific model class.
         """
         config = config.copy()
-        dict_update_nested(config, kwargs)
+        config.update(kwargs)
         return cls(**config)
 
 

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -22,6 +22,26 @@ TASKMODULE_CONFIG_TYPE_KEY = "taskmodule_type"
 T = TypeVar("T", bound="PieBaseHFHubMixin")
 
 
+def dict_update_nested(d: dict, u: dict) -> None:
+    """
+    Update a dictionary with another dictionary, recursively.
+
+    Args:
+        d (`dict`):
+            The original dictionary to update.
+        u (`dict`):
+            The dictionary to use for the update.
+
+    Returns:
+        None
+    """
+    for k, v in u.items():
+        if isinstance(v, dict) and k in d:
+            dict_update_nested(d[k], v)
+        else:
+            d[k] = v
+
+
 class PieBaseHFHubMixin:
     """
     A generic mixin to integrate ANY machine learning framework with the Hub.
@@ -341,7 +361,7 @@ class PieBaseHFHubMixin:
                 Additional keyword arguments passed along to the specific model class.
         """
         config = config.copy()
-        config.update(kwargs)
+        dict_update_nested(config, kwargs)
         return cls(**config)
 
 
@@ -422,7 +442,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
     ) -> TModel:
 
         config = (config or {}).copy()
-        config.update(model_kwargs)
+        dict_update_nested(config, model_kwargs)
         if cls.config_type_key is not None:
             config.pop(cls.config_type_key)
         model = cls(**config)
@@ -480,7 +500,7 @@ class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
         **taskmodule_kwargs,
     ) -> TTaskModule:
         config = (config or {}).copy()
-        config.update(taskmodule_kwargs)
+        dict_update_nested(config, taskmodule_kwargs)
         if cls.config_type_key is not None:
             config.pop(cls.config_type_key)
 

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -366,7 +366,9 @@ class PieBaseHFHubMixin:
         return cls._from_config(config=config, **kwargs)
 
     @classmethod
-    def _from_config(cls: Type[T], config: dict, **kwargs) -> T:
+    def _from_config(
+        cls: Type[T], config: dict, config_override: Optional[TOverride] = None, **kwargs
+    ) -> T:
         """
         Instantiate from a configuration object.
 
@@ -377,7 +379,7 @@ class PieBaseHFHubMixin:
                 Additional keyword arguments passed along to the specific model class.
         """
         config = config.copy()
-        config.update(kwargs)
+        dict_update_nested(config, kwargs, override=config_override)
         return cls(**config)
 
 

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -37,6 +37,8 @@ def dict_update_nested(d: dict, u: dict) -> None:
     """
     for k, v in u.items():
         if isinstance(v, dict) and k in d:
+            if not isinstance(d[k], dict):
+                raise ValueError(f"Cannot merge {d[k]} and {v} because {d[k]} is not a dict.")
             dict_update_nested(d[k], v)
         else:
             d[k] = v

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -10,7 +10,7 @@ from torchmetrics import Metric
 from tqdm import tqdm
 
 from pytorch_ie.core.document import Annotation, Document
-from pytorch_ie.core.hf_hub_mixin import PieTaskModuleHFHubMixin
+from pytorch_ie.core.hf_hub_mixin import PieTaskModuleHFHubMixin, TOverride
 from pytorch_ie.core.module_mixins import PreparableMixin, WithDocumentTypeMixin
 from pytorch_ie.core.registrable import Registrable
 
@@ -165,8 +165,15 @@ class TaskModule(
         return taskmodule
 
     @classmethod
-    def _from_config(cls: Type["TaskModule"], config: Dict[str, Any], **kwargs) -> "TaskModule":
-        taskmodule: TaskModule = super()._from_config(config, **kwargs)
+    def _from_config(
+        cls: Type["TaskModule"],
+        config: Dict[str, Any],
+        config_override: Optional[TOverride] = None,
+        **kwargs,
+    ) -> "TaskModule":
+        taskmodule: TaskModule = super()._from_config(
+            config, config_override=config_override, **kwargs
+        )
         taskmodule.post_prepare()
         return taskmodule
 


### PR DESCRIPTION
With this PR, it is now possible to overwrite individual config entries that are arbitrarily nested. Does work for dicts, but not for lists.

This also adds the parameter `config_override` to `_from_pretrained` and `_from_config` to provide fine-grained control over this behavior. It accepts a `bool` value or a `dict` mapping from config keys to `bool` or `dict` values again, this can be recursive. If `True`, the value for the respective key (or the whole config, on the top level) is taken from the keyword arguments. If `False`, the keyword argument is discarded and the respective config value is taken. If it is `None` or if no `bool` value is set for the respective key, the keyword arguments are merged recursively into the config .

TODO:
 - [x] test in downstream setup