### PR TITLE
derive `PyTorchIEPipeline` from `pie_core.AnnotationPipeline`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2044,16 +2044,20 @@ name = "pie-core"
 version = "0.2.0"
 description = "Core modules of PyTorch-IE"
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = "^3.9"
 groups = ["main"]
-files = [
-    {file = "pie_core-0.2.0-py3-none-any.whl", hash = "sha256:8bb9740304c9b58246485c9170717d2b947d732d71d2a9d5176f8572d8b98b2a"},
-    {file = "pie_core-0.2.0.tar.gz", hash = "sha256:7e41cbe6b554285acbcae8822d84d97c19820ddd7b27dc9751349eb48bc61eb1"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 huggingface_hub = ">=0.23.4,<0.26.0"
-torch = ">=2.1.0,<3.0.0"
+torch = "^2.1.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/ArneBinder/pie-core.git"
+reference = "tests/annotation_pipeline"
+resolved_reference = "5a088f2c00f91c7722cae16550b33eac56afd6b6"
 
 [[package]]
 name = "platformdirs"
@@ -4048,4 +4052,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "4d5b9e8f9a2897b85fc40bd4148a74726636ce765be4571db74472a886f727d0"
+content-hash = "cc9bf4da86108c04c38e2354be6eefe1611049bc2ca6df5d69da3be4391fac4a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pie-core = ">=0.2.0,<0.3.0"
+#pie-core = ">=0.2.0,<0.3.0"
+pie-core = { git = "https://github.com/ArneBinder/pie-core.git", branch = "tests/annotation_pipeline" }
 torch = ">=1.10"
 pytorch-lightning = "^2"
 torchmetrics = "^1"


### PR DESCRIPTION
This is the last non-breaking piece of the `pie-core` refactor. 

requires: https://github.com/ArneBinder/pie-core/pull/80

TODO:
 - [ ] use release xxx of `pie-core` including https://github.com/ArneBinder/pie-core/pull/80