### PR TITLE
fix and improve github `release.yml` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,7 @@ name: Release
 
 on:
     push:
-        branches:
-            - main
-            - master
+        branches: [main, master]
 
 jobs:
     release:
@@ -25,45 +23,49 @@ jobs:
               run: |
                   pip install --constraint=.github/workflows/constraints.txt pip
                   pip --version
+
             - name: Install Poetry
               uses: snok/install-poetry@v1
               with:
                   version: latest
                   virtualenvs-in-project: true
+
             - name: Check if there is a parent commit
               id: check-parent-commit
               run: |
-                  echo "::set-output name=sha::$(git rev-parse --verify --quiet HEAD^)"
+                  echo "sha=$(git rev-parse --verify --quiet HEAD^)" >> "$GITHUB_OUTPUT"
+
             - name: Detect and tag new version
               id: check-version
               if: steps.check-parent-commit.outputs.sha
               uses: salsify/action-detect-and-tag-new-version@v2.0.3
               with:
                   version-command: |
-                      bash -o pipefail -c "poetry version | awk '{ print \$2 }'"
+                      bash -o pipefail -c "poetry version -s"
+
             - name: Bump version for developmental release
               if: "! steps.check-version.outputs.tag"
               run: |
-                  poetry version patch &&
-                  version=$(poetry version | awk '{ print $2 }') &&
-                  poetry version $version.dev.$(date +%s)
+                  poetry version patch
+                  poetry version "$(poetry version -s).dev.$(date -u +%s)"
+
             - name: Build package
-              run: |
-                  poetry build --ansi
+              run: poetry build --ansi
+
             - name: Publish package on PyPI
               if: steps.check-version.outputs.tag
-              uses: pypa/gh-action-pypi-publish@v1.10.3
+              uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   user: __token__
                   password: ${{ secrets.PYPI_TOKEN }}
 
             - name: Publish package on TestPyPI
               if: "! steps.check-version.outputs.tag"
-              uses: pypa/gh-action-pypi-publish@v1.10.3
+              uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   user: __token__
                   password: ${{ secrets.TEST_PYPI_TOKEN }}
-                  repository_url: https://test.pypi.org/legacy/
+                  repository-url: https://test.pypi.org/legacy/
                   verbose: true
 
             - name: Publish the release notes


### PR DESCRIPTION
Should fix the following error (e.g., in step "Publish package on TestPyPI)":
```
 Checking dist/pytorch_ie-0.31.11.dev1758471385-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2, 2.3.
```

The change to fix this is to use `pypa/gh-action-pypi-publish@release/v1`. Other changes are minor improvements / modernizations.