### PR TITLE
allow `pie-core 0.3.0` and update lock file to that version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1429,19 +1429,18 @@ files = [
 
 [[package]]
 name = "pie-core"
-version = "0.2.1"
+version = "0.3.0"
 description = "Core modules of PyTorch-IE"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "pie_core-0.2.1-py3-none-any.whl", hash = "sha256:16721576391807841eed81081c87801a77554c01d157d5b2a29ae328476254f7"},
-    {file = "pie_core-0.2.1.tar.gz", hash = "sha256:2f38e2660d7dba204d3c229cbd93490595b767c4986b68f02897756bff0b5901"},
+    {file = "pie_core-0.3.0-py3-none-any.whl", hash = "sha256:0c2f6c91457c0a05826ccf127b3c40d4f4afb2862a56b82cab6f52d43066719c"},
+    {file = "pie_core-0.3.0.tar.gz", hash = "sha256:ee3892ad3eee414e194005ef1eb453ec1698d37e5a0d80c5583b40f1bb4e8cca"},
 ]
 
 [package.dependencies]
 huggingface_hub = ">=0.23.4,<0.26.0"
-torch = ">=2.1.0,<3.0.0"
 
 [[package]]
 name = "platformdirs"
@@ -2672,4 +2671,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "848e046c36ad55987ac03b3e5e0b33a4a70443b4877b77ca87fbdd8983c7e2b5"
+content-hash = "2f24782e19c56de1bde25f01141d40861b9007418300ed5c70191299049f72e7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = [ "classifiers" ]
 
 requires-python = ">=3.9,<4.0"
 dependencies = [
-    "pie-core >=0.2.1, <0.3",
+    "pie-core >=0.2.1, <0.4.0",
     "torch >=1.10",
     "pytorch-lightning >=2, <3",
     "torchmetrics >1, <2",


### PR DESCRIPTION
see https://github.com/ArneBinder/pie-core/releases/tag/v0.3.0

This is **breaking'** because pie-core 0.3.0 was a breaking release and some of these elements re-exported:
 - `WithDocumentTypeMixin` (alias: `RequiresDocumentTypeMixin`)
 - (`AnnotationPipeline`|`Model`|`TaskModule`).(`from_pretrained`|`save_pretrained`)