### PR TITLE
remove `fsspec` constraint from dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2671,4 +2671,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "2f24782e19c56de1bde25f01141d40861b9007418300ed5c70191299049f72e7"
+content-hash = "41b9146c4a075dccea911a688d3b42819cdecf86459effc0f2b5073fc7d4db22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,6 @@ dependencies = [
     "transformers >=4.18, <5",
     # required for metrics: f1, confusion_matrix, and statsistics
     "pandas >=2.0.0, <3",
-    # TODO: move to pie-datasets!
-    # pin to version below 2023.9.0 because that causes problems when using load_dataset with local files (e.g. json)
-    "fsspec <2023.9.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
since it is soon covered in pie-datasets, see https://github.com/ArneBinder/pie-datasets/pull/198

**breaking** since it does not enforce dependency constraints anymore