### PR TITLE
fix `test_pipeline_with_documents`

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -109,6 +109,8 @@ def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inpl
 @pytest.mark.slow
 @pytest.mark.parametrize("inplace", [False, True])
 def test_pipeline_with_documents(documents, prepared_taskmodule, mock_model, inplace):
+    # make a copy to ensure original documents are not modified in non-inplace mode
+    documents = [doc.copy() for doc in documents]
     pipeline = Pipeline(model=mock_model, taskmodule=prepared_taskmodule, device=-1)
 
     returned_documents = pipeline(documents, inplace=inplace)


### PR DESCRIPTION
make a copy to ensure original documents are not modified in non-inplace mode. 

background: This is a regression introduced in #498, where we changed the scope of the `documents` fixture to `module`.