### PR TITLE
fix failing test `test_pipeline_with_documents`

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -106,7 +106,6 @@ def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inpl
         assert returned_document.entities.predictions
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("inplace", [False, True])
 def test_pipeline_with_documents(documents, prepared_taskmodule, mock_model, inplace):
     # make a copy to ensure original documents are not modified in non-inplace mode

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,6 +88,7 @@ def mock_model(monkeypatch, documents, prepared_taskmodule):
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("inplace", [False, True])
 def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inplace):
     # make a copy to ensure original documents are not modified in non-inplace mode
@@ -108,6 +109,7 @@ def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inpl
         assert returned_document.entities.predictions
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("inplace", [False, True])
 def test_pipeline_with_documents(documents, prepared_taskmodule, mock_model, inplace):
     # make a copy to ensure original documents are not modified in non-inplace mode

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,7 +88,6 @@ def mock_model(monkeypatch, documents, prepared_taskmodule):
     )
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("inplace", [False, True])
 def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inplace):
     document = documents[1]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -90,7 +90,8 @@ def mock_model(monkeypatch, documents, prepared_taskmodule):
 
 @pytest.mark.parametrize("inplace", [False, True])
 def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inplace):
-    document = documents[1]
+    # make a copy to ensure original documents are not modified in non-inplace mode
+    document = documents[1].copy()
     pipeline = PyTorchIEPipeline(model=mock_model, taskmodule=prepared_taskmodule, device=-1)
 
     returned_document = pipeline(document, inplace=inplace)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -92,6 +92,8 @@ def mock_model(monkeypatch, documents, prepared_taskmodule):
 def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inplace):
     # make a copy to ensure original documents are not modified in non-inplace mode
     document = documents[1].copy()
+    assert len(document.entities.predictions) == 0, "Document should not have predictions yet"
+
     pipeline = PyTorchIEPipeline(model=mock_model, taskmodule=prepared_taskmodule, device=-1)
 
     returned_document = pipeline(document, inplace=inplace)
@@ -110,6 +112,10 @@ def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inpl
 def test_pipeline_with_documents(documents, prepared_taskmodule, mock_model, inplace):
     # make a copy to ensure original documents are not modified in non-inplace mode
     documents = [doc.copy() for doc in documents]
+    assert all(
+        len(doc.entities.predictions) == 0 for doc in documents
+    ), "Documents should not have predictions yet"
+
     pipeline = PyTorchIEPipeline(model=mock_model, taskmodule=prepared_taskmodule, device=-1)
 
     returned_documents = pipeline(documents, inplace=inplace)


### PR DESCRIPTION
#505 did not work out as expected, so we need to try again.

Note that this test fails **only on the main branch CI**, since it is (was) marked as `slow`. unfortunately, I can not reproduce locally.

TODO:
 - [x] temporarily make `test_pipeline_with_documents` not slow to run it in PR CI: does not fail here either
 - [x] investigate further
 - [x] make `test_pipeline_with_documents` slow again